### PR TITLE
Avoid pty.h on only non-glibc systems, rather than on non-Linux

### DIFF
--- a/cbits/fork_exec_with_pty.c
+++ b/cbits/fork_exec_with_pty.c
@@ -13,9 +13,9 @@
 
 #if defined(__APPLE__)
 #include <util.h>
-#elif defined(__linux__)
+#elif defined(__GLIBC__)
 #include <pty.h>
-#else /* bsd */
+#else /* bsd without glibc */
 #include <libutil.h>
 #endif
 


### PR DESCRIPTION
There are non-Linux glibc systems which have pty.h, such as Debian's ports to the GNU Hurd and the FreeBSD kernel.  This fix makes posix-pty buildable on such systems.

Thanks!