### PR TITLE
Extra-Libraries is for system libraries.

### DIFF
--- a/posix-pty.cabal
+++ b/posix-pty.cabal
@@ -43,7 +43,7 @@ Library
                ,        unix >= 2.6
 
   if os(linux) || os(freebsd)
-    Extra-Libraries: util
+    Build-Depends: util
 
 Test-Suite stty
   Type: exitcode-stdio-1.0


### PR DESCRIPTION
Use Build-Depends for util.

For more information, see input-output-hk/stack2nix#149 .