### PR TITLE
Working on issue #15 (work in progress)

### DIFF
--- a/System/Posix/Pty.hs
+++ b/System/Posix/Pty.hs
@@ -54,7 +54,7 @@ module System.Posix.Pty (
 import Control.Applicative
 #endif
 
-import Control.Concurrent (newMVar, withMVar, MVar)
+import Control.Concurrent (withMVar)
 import Control.Exception (bracket, throwIO, ErrorCall(..))
 import Control.Monad (when)
 
@@ -73,7 +73,6 @@ import Foreign.C.String (CString, newCString)
 import Foreign.C.Types
 
 import System.IO.Error (mkIOError, eofErrorType)
-import System.IO.Unsafe (unsafePerformIO)
 import System.Posix.IO (fdReadBuf, fdWriteBuf,closeFd)
 import System.Posix.Types
 import System.Process.Internals (mkProcessHandle, runInteractiveProcess_lock, ProcessHandle)

--- a/System/Posix/Pty.hs
+++ b/System/Posix/Pty.hs
@@ -198,8 +198,6 @@ ptyDimensions (Pty fd) = alloca $ \x -> alloca $ \y -> do
 --
 -- > pty <- spawnWithPty (Just [("SHELL", "tcsh")]) True "ls" ["-l"] (20, 10)
 --
-
-
 -- This searches the user's PATH for a binary called @ls@, then runs this
 -- binary with the commandline argument @-l@ in a terminal that is 20
 -- characters wide and 10 characters high. The environment of @ls@ will

--- a/System/Posix/Pty.hs
+++ b/System/Posix/Pty.hs
@@ -280,13 +280,13 @@ foreign import capi unsafe "sys/ioctl.h value TIOCPKT_DOSTOP"
 foreign import capi unsafe "sys/ioctl.h value TIOCPKT_NOSTOP"
     tiocPktNoStop :: Word8
 
-foreign import ccall "pty_size.h"
+foreign import ccall unsafe "pty_size.h"
     set_pty_size :: Fd -> Int -> Int -> IO CInt
 
-foreign import ccall "pty_size.h"
+foreign import ccall unsafe "pty_size.h"
     get_pty_size :: Fd -> Ptr Int -> Ptr Int -> IO CInt
 
-foreign import ccall "fork_exec_with_pty.h"
+foreign import ccall unsafe "fork_exec_with_pty.h"
     fork_exec_with_pty :: Int
                        -> Int
                        -> CInt

--- a/System/Posix/Pty.hs
+++ b/System/Posix/Pty.hs
@@ -282,13 +282,13 @@ foreign import capi unsafe "sys/ioctl.h value TIOCPKT_DOSTOP"
 foreign import capi unsafe "sys/ioctl.h value TIOCPKT_NOSTOP"
     tiocPktNoStop :: Word8
 
-foreign import ccall unsafe "pty_size.h"
+foreign import ccall "pty_size.h"
     set_pty_size :: Fd -> Int -> Int -> IO CInt
 
-foreign import ccall unsafe "pty_size.h"
+foreign import ccall "pty_size.h"
     get_pty_size :: Fd -> Ptr Int -> Ptr Int -> IO CInt
 
-foreign import ccall unsafe "fork_exec_with_pty.h"
+foreign import ccall "fork_exec_with_pty.h"
     fork_exec_with_pty :: Int
                        -> Int
                        -> CInt

--- a/cbits/fork_exec_with_pty.c
+++ b/cbits/fork_exec_with_pty.c
@@ -21,7 +21,6 @@
 
 #include <HsFFI.h>
 
-#include "HsBase.h"
 #include "Rts.h"
 
 // Rts internal API, not exposed in a public header file

--- a/cbits/fork_exec_with_pty.c
+++ b/cbits/fork_exec_with_pty.c
@@ -49,8 +49,6 @@ fork_exec_with_pty
     int packet_mode = 1;
     struct winsize ws;
 
-    int ret = pty;
-
     /* Set the terminal size and settings. */
     memset(&ws, 0, sizeof ws);
     ws.ws_col = sx;
@@ -61,6 +59,9 @@ fork_exec_with_pty
     stopTimer();
 
     *child_pid = forkpty(&pty, NULL, NULL, &ws);
+
+    int ret = pty;
+
     switch (*child_pid) {
     case -1:
         unblockUserSignals();

--- a/posix-pty.cabal
+++ b/posix-pty.cabal
@@ -33,7 +33,7 @@ Library
   Other-Modules:        
 
   C-Sources:            cbits/fork_exec_with_pty.c cbits/pty_size.c
-  CC-Options:           -Wall -Wextra -pedantic -std=c99
+  CC-Options:           -Wall -Wextra -std=c99
   Include-Dirs:         cbits
   Includes:             fork_exec_with_pty.h pty_size.h
 

--- a/posix-pty.cabal
+++ b/posix-pty.cabal
@@ -39,7 +39,7 @@ Library
 
   Build-Depends:        base >= 4 && < 5
                ,        bytestring >= 0.10
-               ,        process >= 1.2
+               ,        process >= 1.6.6.0
                ,        unix >= 2.6
 
   if os(linux) || os(freebsd)


### PR DESCRIPTION
This is some progress I've made on issue #15. It doesn't solve the problem yet but I'm putting it up now to gather feedback/advice.

I've been trying to follow the approach of the `process` library to make the fork call inside `posix-pty` play nicely with the GHC RTS. See how `blockUserSignals`/`unblockUserSignals` and `stopTimer`/`startTimer` are used here: https://github.com/haskell/process/blob/master/cbits/runProcess.c#L137

I think adding `unsafe` to the `foreign import ccall` lines is a good idea no matter what; see http://wiki.haskell.org/GHC/Using_the_FFI#Improving_efficiency