### PR TITLE
Expose all fields of the winsize struct

### DIFF
--- a/cbits/fork_exec_with_pty.c
+++ b/cbits/fork_exec_with_pty.c
@@ -38,6 +38,8 @@ int
 fork_exec_with_pty
     ( HsInt sx
     , HsInt sy
+    , HsInt sxpixel
+    , HsInt sypixel
     , int search
     , const char *file
     , char *const argv[]
@@ -53,6 +55,8 @@ fork_exec_with_pty
     memset(&ws, 0, sizeof ws);
     ws.ws_col = sx;
     ws.ws_row = sy;
+    ws.ws_xpixel = sxpixel;
+    ws.ws_ypixel = sypixel;
 
     /* Fork and exec, returning the master pty. */
     blockUserSignals();

--- a/cbits/fork_exec_with_pty.c
+++ b/cbits/fork_exec_with_pty.c
@@ -1,3 +1,4 @@
+#define _DEFAULT_SOURCE
 #define _BSD_SOURCE
 #include <sys/ioctl.h>
 

--- a/cbits/fork_exec_with_pty.h
+++ b/cbits/fork_exec_with_pty.h
@@ -7,6 +7,8 @@ int
 fork_exec_with_pty
     ( HsInt sx
     , HsInt sy
+    , HsInt sxpixel
+    , HsInt sypixel
     , int search
     , const char *file
     , char *const argv[]

--- a/cbits/pty_size.c
+++ b/cbits/pty_size.c
@@ -7,7 +7,7 @@
 #include "pty_size.h"
 
 int
-set_pty_size(int fd, HsInt x, HsInt y)
+set_pty_size(int fd, HsInt x, HsInt y, HsInt xpixel, HsInt ypixel)
 {
     struct winsize ws;
 
@@ -15,12 +15,14 @@ set_pty_size(int fd, HsInt x, HsInt y)
     memset(&ws, 0, sizeof ws);
     ws.ws_col = x;
     ws.ws_row = y;
+    ws.ws_xpixel = xpixel;
+    ws.ws_ypixel = ypixel;
 
     return ioctl(fd, TIOCSWINSZ, &ws);
 }
 
 int
-get_pty_size(int fd, HsInt *x, HsInt *y)
+get_pty_size(int fd, HsInt *x, HsInt *y, HsInt *xpixel, HsInt *ypixel)
 {
     int result;
     struct winsize ws;
@@ -31,6 +33,8 @@ get_pty_size(int fd, HsInt *x, HsInt *y)
 
     *x = ws.ws_col;
     *y = ws.ws_row;
+    *xpixel = ws.ws_xpixel;
+    *ypixel = ws.ws_ypixel;
 
     return result;
 }

--- a/cbits/pty_size.h
+++ b/cbits/pty_size.h
@@ -4,9 +4,9 @@
 #include <HsFFI.h>
 
 int
-set_pty_size(int fd, HsInt x, HsInt y);
+set_pty_size(int fd, HsInt x, HsInt y, HsInt xpixel, HsInt ypixel);
 
 int
-get_pty_size(int fd, HsInt *x, HsInt *y);
+get_pty_size(int fd, HsInt *x, HsInt *y, HsInt *xpixel, HsInt *ypixel);
 
 #endif

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,3 @@
+{ pkgs ? import <nixpkgs> {}, args ? {} }:
+
+pkgs.haskell.lib.dontCheck (pkgs.haskellPackages.callCabal2nix "posix-pty" ./. args)


### PR DESCRIPTION
This pull request adds variants of all functions that handle pty dimensions (`resizePty`, `ptyDimensions` and `spawnWithPty`) to allow access to the `ws_xpixel` and `ws_ypixel` fields of the `winsize` struct. The fields are used to communicate dimensions in screen pixels and are, for example, required by kittys [icat protocol](https://sw.kovidgoyal.net/kitty/kittens/icat.html).

I have added new functions instead of changing existing signatures to keep the API stable, but if that is not required, I'd be happy to update the pull request to change the existing functions instead.

There is also an unrelated commit to fix a glibc-warning and a commit that adds support for the nix package manager, which I can remove if preferred.